### PR TITLE
feat(security): block unsafe HTML tags in police alerts to prevent XSS

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -145,8 +145,21 @@ RegisterNetEvent('qb-policejob:server:evidence', function(currentEvidence)
     })
 end)
 
+local unsafeTags = {
+    "<script", "</script", "<img", "<iframe", "<object", "<embed", "<svg",
+    "<link", "<style", "<meta", "<html", "<body", "<video", "<audio", "<a"
+}
+
 RegisterNetEvent('police:server:policeAlert', function(text)
     local src = source
+
+    local lowerText = string.lower(text or "")
+    for _, tag in pairs(unsafeTags) do
+        if string.find(lowerText, tag) then
+            return 
+        end
+    end
+
     local ped = GetPlayerPed(src)
     local coords = GetEntityCoords(ped)
     local players = QBCore.Functions.GetQBPlayers()


### PR DESCRIPTION
###  Security Fix: Prevent XSS in Police Alerts

**What this PR does:**
This PR adds a validation step in the `police:server:policeAlert` server event to block potentially dangerous HTML tags (e.g., `<script>`, `<img>`, `<iframe>`, etc.) from being used in the `text` input.  
This ensures that players cannot inject malicious code that would be displayed on the client, thereby preventing Cross-Site Scripting (XSS) attacks.

---

### Describe Pull Request

This PR introduces a simple but effective security measure that improves the overall safety of police alert messages sent to client UIs.

**Why it should be included in core:**
Any server accepting user-submitted text without validation is vulnerable to abuse. This fix ensures alerts cannot be used to inject harmful HTML, which is crucial for roleplay integrity and client security.

---

### 🧾 Fixes

No specific GitHub issue referenced, but mitigates a potential security vulnerability in the base code.

---

###  Questions

- **Have you personally loaded this code into an updated QBCore project and checked all its functionality?**  
   Yes

- **Does your code fit the style guidelines?**  
   Yes

- **Does your PR fit the contribution guidelines?**  
   Yes
